### PR TITLE
Setler::SettingNotFound raised when destroying a setting that does not exist

### DIFF
--- a/lib/setler.rb
+++ b/lib/setler.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 
 require_relative 'setler/version'
+require_relative 'setler/exceptions'
 require_relative 'setler/settings'
 require_relative 'setler/active_record'
 

--- a/lib/setler/exceptions.rb
+++ b/lib/setler/exceptions.rb
@@ -1,0 +1,4 @@
+module Setler
+  class SettingNotFound < StandardError
+  end
+end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -63,4 +63,10 @@ class Setler::SettingsTest < Test::Unit::TestCase
     Setler::Settings.destroy :test
     assert_nil Setler::Settings.test
   end
+
+  def test_destroy_when_setting_does_not_exist
+    assert_raise Setler::SettingNotFound do
+      Setler::Settings.destroy :not_a_setting
+    end
+  end
 end


### PR DESCRIPTION
Defines the `Setler::SettingNotFound` exception that was missing in the current codebase and adds a test.

100% C0 test coverage OMG.
