### PR TITLE
set_table_name is deprecated in Rails 3.2

### DIFF
--- a/lib/setler/scoped_settings.rb
+++ b/lib/setler/scoped_settings.rb
@@ -1,7 +1,7 @@
 module Setler
   class ScopedSettings < Settings
     def self.for_thing(object, scopename)
-      set_table_name scopename
+      self.table_name = scopename
       @object = object
       self
     end


### PR DESCRIPTION
The is to fix the deprecation warning thrown by Rails 3.2

Calling set_table_name is deprecated. Please use `self.table_name =
'the_name'` instead.
