### PR TITLE
make concrete implementations independent

### DIFF
--- a/lib/setler/settings.rb
+++ b/lib/setler/settings.rb
@@ -3,8 +3,9 @@ module Setler
     serialize :value
     self.abstract_class = true
     
-    cattr_accessor :defaults
-    @@defaults = {}.with_indifferent_access
+    def self.defaults
+      @defaults ||= {}.with_indifferent_access
+    end
     
     # Get and Set variables when the calling method is the variable name
     def self.method_missing(method, *args, &block)
@@ -22,7 +23,7 @@ module Setler
 
     def self.[](var)
       the_setting = thing_scoped.find_by_var(var.to_s)
-      the_setting.present? ? the_setting.value : @@defaults[var]
+      the_setting.present? ? the_setting.value : defaults[var]
     end
 
     def self.[]=(var, value)
@@ -48,7 +49,7 @@ module Setler
     end
     
     def self.all
-      @@defaults.merge(Hash[thing_scoped.all.collect{ |s| [s.var, s.value] }])
+      defaults.merge(Hash[thing_scoped.all.collect{ |s| [s.var, s.value] }])
     end
     
     def self.thing_scoped

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -114,7 +114,7 @@ class ::SettingsTest < Test::Unit::TestCase
   def test_user_settings_all
     ::Settings.destroy_all
     user = User.create name: 'user 1'
-    assert_equal ::Settings.all, user.preferences.all
+    assert_equal ::Preferences.all, user.preferences.all
     user.preferences.likes_bacon = true
     user.preferences.really_likes_bacon = true
     assert user.preferences.all['likes_bacon']
@@ -145,5 +145,17 @@ class ::SettingsTest < Test::Unit::TestCase
     assert_raise Setler::SettingNotFound do
       ::Settings.destroy :not_a_setting
     end
+  end
+
+  def test_implementations_are_independent
+    ::Preferences.create(:var => 'test',  :value => 'preferences foo')
+    ::Preferences.create(:var => 'test2', :value => 'preferences bar')
+
+    assert_not_equal ::Settings.defaults, ::Preferences.defaults
+
+    assert_equal 'foo', ::Settings[:test]
+    assert_equal 'bar', ::Settings[:test2]
+    assert_equal 'preferences foo', ::Preferences[:test]
+    assert_equal 'preferences bar', ::Preferences[:test2]
   end
 end


### PR DESCRIPTION
enables an application to have, for example, Features and
Settings, without sharing the `defaults` implementation.

in this way, Setler may be used to configure feature flags as
well as user-specific settings, which have differing needs.
