### PR TITLE
Mass-Assignment Error

### DIFF
--- a/lib/setler/settings.rb
+++ b/lib/setler/settings.rb
@@ -6,6 +6,8 @@ module Setler
     cattr_accessor :defaults
     @@defaults = {}.with_indifferent_access
 
+    attr_accessible :var, :value if respond_to?(:attr_accessible)
+
     # Get and Set variables when the calling method is the variable name
     def self.method_missing(method, *args, &block)
       if respond_to?(method)


### PR DESCRIPTION
In Rails > 3.0 assigning settings results in a mass-assignment error.
