### PR TITLE
Fix has_setler call example.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,7 +50,7 @@ Note: Updating the setting to nil or false no longer makes it the default settin
 Add them to any ActiveRecord object:
 
   class User < ActiveRecord::Base
-    has_setler as: :settings
+    has_setler  :settings
   end
   
 Then you get:


### PR DESCRIPTION
After reading the code, it seems to me has_setler requires only a single argument (the table).
