### PR TITLE
Upgraded to Ruby 2.2.3; Fixed timestamps migration; Moved to https for source in Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ coverage.data
 .bundle
 Gemfile.lock
 pkg/*
+# Added so not to force others to use .rvmrc and .overcommit.yml files.
+.rvmrc
+.overcommit.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 rvm:
   - 1.9.3
   - 2.1.2
+  - 2.2.3
 cache: bundler
 script:
   - bundle exec rake test
 notifications:
   email: false
+sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in setler.gemspec
 gemspec

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,7 +34,7 @@ def setup_db
       t.text   :value, :null => true
       t.integer :thing_id, :null => true
       t.string :thing_type, :limit => 30, :null => true
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :settings, [ :thing_type, :thing_id, :var ], :unique => true
 
@@ -43,7 +43,7 @@ def setup_db
       t.text   :value, :null => true
       t.integer :thing_id, :null => true
       t.string :thing_type, :limit => 30, :null => true
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :preferences, [ :thing_type, :thing_id, :var ], :unique => true
 


### PR DESCRIPTION
 * Added support for Ruby 2.2.3 in .travis.yml file.
 * Fixed timestamps migrations to remove warning during "rake" run.
 * Moved to https for source command in Gemfile.