### PR TITLE
Add partial unique index for app wide settings

### DIFF
--- a/lib/generators/setler/templates/migration.rb
+++ b/lib/generators/setler/templates/migration.rb
@@ -9,6 +9,7 @@ class SetlerCreate<%= table_name.camelize %> < ActiveRecord::Migration
     end
 
     add_index :<%= table_name %>, [ :thing_type, :thing_id, :var ], unique: true
+    add_index :<%= table_name %>, :var, unique: true, where: "thing_id IS NULL AND thing_type is NULL"
   end
 
   def self.down

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -76,6 +76,15 @@ class ::SettingsTest < Minitest::Test
     assert_equal '123', ::Settings.onetwothree
   end
 
+  def test_multithreaded_create
+    s1 = Settings.new var: :conflict, value: 1
+    s2 = Settings.new var: :conflict, value: 2
+    s1.save!
+    assert_raises ActiveRecord::RecordNotUnique do
+      s2.save!
+    end
+  end
+
   def test_complex_serialization
     complex = [1, '2', {:three => true}]
     ::Settings.complex = complex

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,6 +40,7 @@ def setup_db
       t.timestamps null: false
     end
     add_index :settings, [ :thing_type, :thing_id, :var ], :unique => true
+    add_index :settings, :var, unique: true, where: "thing_id IS NULL AND thing_type is NULL"
 
     create_table :preferences do |t|
       t.string :var, :null => false
@@ -49,6 +50,7 @@ def setup_db
       t.timestamps null: false
     end
     add_index :preferences, [ :thing_type, :thing_id, :var ], :unique => true
+    add_index :preferences, :var, unique: true, where: "thing_id IS NULL AND thing_type is NULL"
 
     create_table :users do |t|
       t.string :name


### PR DESCRIPTION
This index makes sure there are no two settings record with the same
name even if both of them are created concurrently.