### PR TITLE
Fix test of uniqueness constaints on global configuration

### DIFF
--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -80,8 +80,11 @@ class ::SettingsTest < Minitest::Test
     s1 = Settings.new var: :conflict, value: 1
     s2 = Settings.new var: :conflict, value: 2
     s1.save!
-    assert_raises ActiveRecord::RecordNotUnique do
-      s2.save!
+    exc = assert_raises ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid do
+        s2.save!
+    end
+    if exc.is_a? ActiveRecord::StatementInvalid
+      assert exc.message.match(/UNIQUE/)
     end
   end
 


### PR DESCRIPTION
Add support for ActiveRecord 3 behavior of raising ActiveRecord::StatementInvalid in case of uniqueness constraint failure.