### PR TITLE
Fix failing travis build by conditionalizing assertion

### DIFF
--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -83,7 +83,7 @@ class ::SettingsTest < Minitest::Test
     exc = assert_raises ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid do
         s2.save!
     end
-    if exc.is_a? ActiveRecord::StatementInvalid
+    unless exc.is_a?(ActiveRecord::RecordNotUnique)
       assert exc.message.match(/UNIQUE/)
     end
   end


### PR DESCRIPTION
The assertion about the string "UNIQUE" is relevant only in the case of
activerecord 3.
The previous code did not work correctly because ActiveRecord::RecordNotUnique is actually a descendant of ActiveRecord::StatementInvalid.