### PR TITLE
Upgraded edge Rails to latest version plus added 2 exceptions to .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,7 @@ matrix:
       gemfile: gemfiles/rails_5.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails_5_edge.gemfile
+    - rvm: 2.2.9
+      gemfile: gemfiles/rails_5_edge.gemfile
+    - rvm: 2.3.6
+      gemfile: gemfiles/rails_5_edge.gemfile

--- a/gemfiles/rails_4.gemfile.lock
+++ b/gemfiles/rails_4.gemfile.lock
@@ -67,7 +67,7 @@ GEM
     minitest (5.11.3)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    rack (1.6.8)
+    rack (1.6.9)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.10)

--- a/gemfiles/rails_5_edge.gemfile.lock
+++ b/gemfiles/rails_5_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails
-  revision: 042c1e076a4ee3172c9ce95864d1e773b7ef38f8
+  revision: 690d2a49465cf18b93cf66b77967cb1236c881cb
   specs:
     actioncable (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)

--- a/gemfiles/rails_5_edge.gemfile.lock
+++ b/gemfiles/rails_5_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails
-  revision: 5ecbeda0e225e4961977b5c516088cf12d92319f
+  revision: f9fa1a9dca4a3808bd38ff490dc8ee899813f181
   specs:
     actioncable (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)

--- a/gemfiles/rails_5_edge.gemfile.lock
+++ b/gemfiles/rails_5_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails
-  revision: 690d2a49465cf18b93cf66b77967cb1236c881cb
+  revision: dd943ef0b9d1733523478afcf4992ac078d299d0
   specs:
     actioncable (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)

--- a/gemfiles/rails_5_edge.gemfile.lock
+++ b/gemfiles/rails_5_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails
-  revision: 9208a52220b51cc747f45f11ccfa1cf0de29e8d7
+  revision: 9c0c90979a759a41628e0cd9d73821b0b34d03fc
   specs:
     actioncable (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)

--- a/gemfiles/rails_5_edge.gemfile.lock
+++ b/gemfiles/rails_5_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails
-  revision: f9fa1a9dca4a3808bd38ff490dc8ee899813f181
+  revision: 042c1e076a4ee3172c9ce95864d1e773b7ef38f8
   specs:
     actioncable (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)

--- a/gemfiles/rails_5_edge.gemfile.lock
+++ b/gemfiles/rails_5_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails
-  revision: f1878fa06efb2eaa2c521022fa79f95b6c49f865
+  revision: 70169dca8faf7c037906b7f88d2dff723eaf7187
   specs:
     actioncable (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)

--- a/gemfiles/rails_5_edge.gemfile.lock
+++ b/gemfiles/rails_5_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails
-  revision: 9c0c90979a759a41628e0cd9d73821b0b34d03fc
+  revision: 5ecbeda0e225e4961977b5c516088cf12d92319f
   specs:
     actioncable (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)

--- a/gemfiles/rails_5_edge.gemfile.lock
+++ b/gemfiles/rails_5_edge.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails
-  revision: dd943ef0b9d1733523478afcf4992ac078d299d0
+  revision: f1878fa06efb2eaa2c521022fa79f95b6c49f865
   specs:
     actioncable (6.0.0.alpha)
       actionpack (= 6.0.0.alpha)
@@ -104,7 +104,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     rack (2.0.4)
-    rack-test (0.8.2)
+    rack-test (0.8.3)
       rack (>= 1.0, < 3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)


### PR DESCRIPTION
Upgraded edge Rails to latest version plus added 
2 (2.2.9 and 2.3.6) exceptions to .travis.yml file
because Rails 6.x only supports Ruby >= 2.4.1.

@ckdake: If you don't like the 2 new exceptions, I will back them out.