### PR TITLE
Bump gem version so that most recent changes take affect

### DIFF
--- a/lib/setler/version.rb
+++ b/lib/setler/version.rb
@@ -1,3 +1,3 @@
 module Setler
-  VERSION = "0.0.13"
+  VERSION = "0.0.14"
 end


### PR DESCRIPTION
Rails 6 has a deprecation warning for update attributes this was fixed 4 years ago but the gem version was never updated. This PR updates the gem version so that change will take affect.